### PR TITLE
Rename error

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,22 +142,22 @@ This means, "sleep until the json response is `{'status': 'SUCCESS'}` OR `{'stat
 ## Error conditionals
 
 What if the job we've created fails? We need to be able to respond appropriately, instead of polling the endpoint for a long time,
-waiting for a successful status. To this end, we use the `error` kwarg. If an error is detected, a HttSleepError exception is raised:
+waiting for a successful status. To do this, we set an alarm using the `alarms` kwarg. If an error is detected, a HttSleepAlarm exception is raised:
 
 ```
-from httsleep.exceptions import HttSleepError
+from httsleep.exceptions import HttSleepAlarm
 try:
     httsleep('http://myendpoint/jobs/1', {'status_code': 200, 'json': {'status': 'SUCCESS'}},
-             error=[{'json': {'status': 'ERROR'}}, {'json': {'status': 'CRITICAL'}}, {'status_code': 500}])
-except HttSleepError as e:
+             alarms=[{'json': {'status': 'ERROR'}}, {'json': {'status': 'CRITICAL'}}, {'status_code': 500}])
+except HttSleepAlarm as e:
     if e.response.status_code == 500:
         print "There was an internal system error!"
     else:
         print "The job has error'd out with status {}!".format(e.response.json()['status'])
-        print "The condition that matched this was {}".format(e.error_condition)
+        print "The condition that matched this was {}".format(e.alarm)
 ```
 
-As shown in this code, the actual response is stored within the exception, along with the error condition that matched the response.
+As shown in this code, the actual response is stored within the exception, along with the alarm condition that matched the response.
 
 ## Going crazy
 
@@ -167,12 +167,12 @@ We can see how far this can be taken (perhaps too far) in the next example:
 
 ```
 until = [{'status_code': 200, 'jsonpath': [{'expression': 'status', 'value': 'OK'}]}
-error = [{'json': {'status': 'ERROR'}},
-         {'jsonpath': [{'expression': 'status', 'value': 'UNKNOWN'},
-                       {'expression': 'owner', 'value': 'Chris'}],
-          'callback': is_job_really_failing},
-         {'status_code': 404}]
-httsleep('http://myendpoint/jobs/1', until, error=error)
+alarms = [{'json': {'status': 'ERROR'}},
+          {'jsonpath': [{'expression': 'status', 'value': 'UNKNOWN'},
+                        {'expression': 'owner', 'value': 'Chris'}],
+           'callback': is_job_really_failing},
+          {'status_code': 404}]
+httsleep('http://myendpoint/jobs/1', until, alarms=alarms)
 ```
 
 * Poll `http://myendpoint/jobs/1` until

--- a/httsleep/exceptions.py
+++ b/httsleep/exceptions.py
@@ -1,5 +1,5 @@
-class HttSleepError(Exception):
-    def __init__(self, response, error_condition):
+class HttSleepAlarm(Exception):
+    def __init__(self, response, alarm_condition):
         self.response = response
-        self.error_condition = error_condition
-        self.mesg = 'Response matched an error condition: {}'.format(error_condition)
+        self.alarm = alarm_condition
+        self.mesg = 'Response matched an error condition: {}'.format(alarm_condition)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,7 +39,7 @@ def test_max_retries_default_value():
     assert obj.max_retries == 123
 
     with pytest.raises(ValueError):
-        obj = HttSleep(URL, CONDITION, max_retries='five')
+        HttSleep(URL, CONDITION, max_retries='five')
 
 
 def test_until():
@@ -49,16 +49,16 @@ def test_until():
 
 def test_empty_until():
     with pytest.raises(ValueError):
-        obj = HttSleep(URL, {})
+        HttSleep(URL, {})
     with pytest.raises(ValueError):
-        obj = HttSleep(URL, [{}])
+        HttSleep(URL, [{}])
 
 
 def test_invalid_until():
     with pytest.raises(ValueError):
-        obj = HttSleep(URL, {'lol': 'invalid'})
+        HttSleep(URL, {'lol': 'invalid'})
     with pytest.raises(ValueError):
-        obj = HttSleep(URL, {'status_code': 200, 'lol': 'invalid'})
+        HttSleep(URL, {'status_code': 200, 'lol': 'invalid'})
 
 
 def test_status_code_cast_as_int():
@@ -66,19 +66,20 @@ def test_status_code_cast_as_int():
     assert obj.until[0]['status_code'] == 200
 
 
-def test_error():
-    obj = HttSleep(URL, CONDITION, error={'status_code': 500})
-    assert obj.error == [{'status_code': 500}]
+def test_alarms():
+    obj = HttSleep(URL, CONDITION, alarms={'status_code': 500})
+    assert obj.alarms == [{'status_code': 500}]
+    obj = HttSleep(URL, CONDITION, alarms=[{'status_code': 500}])
+    assert obj.alarms == [{'status_code': 500}]
 
 
-def test_invalid_error():
+def test_invalid_alarms():
     with pytest.raises(ValueError):
-        obj = HttSleep(URL, CONDITION, error={'lol': 'invalid'})
+        HttSleep(URL, CONDITION, alarms={'lol': 'invalid'})
     with pytest.raises(ValueError):
-        obj = HttSleep(URL, CONDITION,
-                       error={'status_code': 500, 'lol': 'invalid'})
+        HttSleep(URL, CONDITION, alarms={'status_code': 500, 'lol': 'invalid'})
 
 
-def test_status_code_cast_as_int_in_error():
-    obj = HttSleep(URL, CONDITION, error={'status_code': '500'})
-    assert obj.error[0]['status_code'] == 500
+def test_status_code_cast_as_int_in_alarm():
+    obj = HttSleep(URL, CONDITION, alarms={'status_code': '500'})
+    assert obj.alarms[0]['status_code'] == 500


### PR DESCRIPTION
Hope you don't mind me highlighting you for this PR, @mathmagique, but I wanted to get your input on the renaming. Main outline:
- `error` is now `alarms`. I feel like this holds true to the idea of the concept ("alert me when something goes wrong in this way"), while also fitting nicely into the "sleep" terminology of the project
- `HttSleepError` is now `HttSleepAlarm`. I'm not too sure about this. The two words `Sleep` and `Alarm` clash. What would you think of an `Alarm` exception? Reason I didn't call it `Alarm` was that it seemed a little too generic. `raise Alarm()` reads terribly nicely, though.

I think that's it. I'll give more thought to your other suggestions in the coming days.
